### PR TITLE
Removed defaults for othe Nginx domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 NGINX_SITE_MAIN=www.qobo.biz
-NGINX_SITE_OTHER=qobo.biz
+NGINX_SITE_OTHER=
 NGINX_ROOT_PREFIX=/var/www/html
 NGINX_LOG_PREFIX=/var/log/nginx
 


### PR DESCRIPTION
Using this .env.example for a server with multiple sites results
in Nginx warnings of multiple servers for the same domain.  It
is also impossible to unset the value in .env.example (see
https://github.com/QoboLtd/phake-builder/issues/55)