### PR TITLE
Relax PHPUnit dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"qobo/phake-builder": "~1.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~5.3",
+		"phpunit/phpunit": "*",
 		"phpunit/phpunit-selenium": "~3.0",
 		"sami/sami": "~3.2"
 	},


### PR DESCRIPTION
This is a template for projects, so we shouldn't insist on any particular PHPUnit version.  Either the underlying tools or the project itself will define what's needed.