### PR TITLE
Fixed BitBucket Pipelines admin user password

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -6,6 +6,6 @@ pipelines:
         script:
           - service mysql start
           - ./bin/composer install --no-interaction --no-progress
-          - ./vendor/bin/phake app:install DB_ADMIN_USER=root DB_ADMIN_USER_PASS=root DB_USER=root DB_USER=root DB_NAME=app
+          - ./vendor/bin/phake app:install DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_USER=root DB_NAME=app
           - ./vendor/bin/phpunit --group example
           - ./vendor/bin/phpunit --exclude-group example


### PR DESCRIPTION
Fix the typo in the variable that provides `app:update` with the
MySQL admin user password.