### PR TITLE
Do not hardcoded username and group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 
 install:
     - ./bin/composer install --no-interaction --no-progress
-    - ./vendor/bin/phake app:install CHOWN_USER=root CHGRP_GROUP=root DB_NAME=app DB_ADMIN_USER=root DB_USER=root
+    - ./vendor/bin/phake app:install CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_USER=root
 
 before_script:
     - sh -e /etc/init.d/xvfb start

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -6,6 +6,6 @@ pipelines:
         script:
           - service mysql start
           - ./bin/composer install --no-interaction --no-progress
-          - ./vendor/bin/phake app:install CHOWN_USER=root CHGRP_GROUP=root DB_NAME=app DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_PASS=root
+          - ./vendor/bin/phake app:install CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_PASS=root
           - ./vendor/bin/phpunit --group example
           - ./vendor/bin/phpunit --exclude-group example


### PR DESCRIPTION
For chown/chgrp operations we need to know which username and
group to use.  This varies from system to system and is not
always reliable.

Therefor we use the $USER environment variable, assuming that:

1. The variable is defined and set to the current username.
2. The group with the same name exists
3. The current user is the member of that group

This works well for combinatinos like root:root, nginx:nginx,
someuser:someuser, etc.