### PR TITLE
Support SSH access to private repositories (task #2554)

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -5,6 +5,12 @@ pipelines:
     - step:
         script:
           - service mysql start
+          - mkdir ~/.ssh
+          - echo $MY_SSH_KEY | base64 --decode > ~/.ssh/id_rsa
+          - echo > ~/.ssh/known_hosts
+          - ssh-keyscan -t rsa bitbucket.org >> ~/.ssh/known_hosts
+          - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+          - chmod -R u+rwX,go-rwX ~/.ssh
           - ./bin/composer install --no-interaction --no-progress
           - ./vendor/bin/phake app:install CHOWN_USER=$USER CHGRP_GROUP=$USER DB_NAME=app DB_ADMIN_USER=root DB_ADMIN_PASS=root DB_USER=root DB_PASS=root
           - ./vendor/bin/phpunit --group example


### PR DESCRIPTION
This is almost verbatim copy-paste from this page:

https://answers.atlassian.com/questions/39429257/how-do-i-set-up-ssh-public-key-authentication-so-that-i-can-use-ssh-sftp-or-scp-from-my-bitbucket-pipelines-pipeline

In order for this to work, add base64-encoded private RSA key to
MY_SSH_KEY environment variable on the account or repository, as
described here:

https://confluence.atlassian.com/bitbucket/environment-variables-in-bitbucket-pipelines-794502608.html