### PR TITLE
The return of the robots.txt (task #2696)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ NGINX_ROOT_PREFIX=/var/www/html
 NGINX_LOG_PREFIX=/var/log/nginx
 NGINX_FASTCGI_PASS=127.0.0.1:9000
 
-ALLOW_ROBOTS=0
+ALLOW_ROBOTS=1
 ALLOW_ROBOTS_EXCEPT_ON=qobocloud.com
 
 TEMPLATE_SRC=etc/nginx.conf.template

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ NGINX_LOG_PREFIX=/var/log/nginx
 NGINX_FASTCGI_PASS=127.0.0.1:9000
 
 ALLOW_ROBOTS=0
+ALLOW_ROBOTS_EXCEPT_ON=qobocloud.com
 
 TEMPLATE_SRC=etc/nginx.conf.template
 TEMPLATE_DST=etc/nginx.conf

--- a/webroot/robots.php
+++ b/webroot/robots.php
@@ -8,6 +8,10 @@
  * of anything on the site.  Setting it to true will
  * either allow everything or only what is defined in
  * the robots.txt file, if it exists and is readable.
+ *
+ * Furthermore, setting ALLOW_ROBOTS_EXCEPT_ON will
+ * disable indexing for any server hostname that matches
+ * the pattern.
  */
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
@@ -26,6 +30,15 @@ $allowRobots = (bool) getenv('ALLOW_ROBOTS');
 
 // Switch MIME type to text/plain
 header('Content-Type: text/plain'); 
+
+// Limit indexing on certain domains
+if ($allowRobots) {
+	$exceptionPattern = (string)getenv('ALLOW_ROBOTS_EXCEPT_ON');
+	$currentDomain = empty($_SERVER['SERVER_NAME']) ? '' : $_SERVER['SERVER_NAME'];
+	if ($exceptionPattern && $currentDomain && preg_match('/' . $exceptionPattern . '/i', $currentDomain)) {
+		$allowRobots = false;
+	}
+}
 
 // Allow indexing
 if ($allowRobots) {


### PR DESCRIPTION
* Default of allowing the robots.txt indexing is back to ON, not OFF.
* Additional control was introduced with `ALLOW_ROBOTS_EXCEPT_ON` domain pattern in `.env`