### PR TITLE
Lock Twig to v1 until we're ready to drop PHP 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 		"phpunit/phpunit": "*",
 		"phpunit/phpunit-selenium": "~3.0",
 		"squizlabs/php_codesniffer": "*",
-		"sami/sami": "~3.2"
+		"sami/sami": "~3.2",
+        "twig/twig": "~1.2"
 	},
 	"suggest": {
 		"ext-xdebug": "Allows code coverage reports and advanced debugging"


### PR DESCRIPTION
Some of the dependencies that we are using, require Twig.  For,
example, Sami documentation generating tool.

The new major version of Twig (v2) drops support for PHP 5 and
requires PHP 7, which we are not ready to do yet.

Sami defines Twig dependency as v1 or v2 (they basically don't
care and work with both).  Composer however tries to get the latest
and if nothing stops it, will get Twig v2.

So, until we are ready to drop support for PHP 5, we are locking
the Twig dependency to v1, which support it.