### PR TITLE
Revert "Lock Twig to v1 until we're ready to drop PHP 5"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
 		"phpunit/phpunit": "*",
 		"phpunit/phpunit-selenium": "~3.0",
 		"squizlabs/php_codesniffer": "*",
-		"sami/sami": "~3.2",
-        "twig/twig": "~1.2"
+		"sami/sami": "~3.2"
 	},
 	"suggest": {
 		"ext-xdebug": "Allows code coverage reports and advanced debugging"


### PR DESCRIPTION
This reverts commit 045eff1a79c069c2a29eca9a29095e0df58b2f92.

This is now done in phake-builder (v2.8.0), where it is more
appropriate.

https://github.com/QoboLtd/phake-builder/releases/tag/v2.8.0