### PR TITLE
BitBucket Pipelines fix for .ssh/ folder (task #3476)

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -5,7 +5,7 @@ pipelines:
     - step:
         script:
           - service mysql start
-          - mkdir ~/.ssh
+          - if [ ! -d ~/.ssh ] ; then mkdir ~/.ssh ; fi
           - echo $MY_SSH_KEY | base64 --decode -i > ~/.ssh/id_rsa
           - echo > ~/.ssh/known_hosts
           - ssh-keyscan -t rsa bitbucket.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
Check if the ~/.ssh folder exists before attempting to create one.
If it's already there, mkdir will fail and the pipeline run will
stop.