### PR TITLE
lock phpunit/php-token-stream to v1.4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": ">=5.6.0",
 		"qobo/phake-builder": "~4.0",
 		"pyrech/composer-changelogs": "~1.4",
-		"phpunit/php-token-stream": "1.4.2"
+		"phpunit/php-token-stream": "~1.4"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
 	"require": {
 		"php": ">=5.6.0",
 		"qobo/phake-builder": "~4.0",
-		"pyrech/composer-changelogs": "~1.4"
+		"pyrech/composer-changelogs": "~1.4",
+		"phpunit/php-token-stream": "1.4.2"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "*",


### PR DESCRIPTION
phpunit/php-code-coverage requires php-token-stream of either 1.4.2+ or 2.0+, but 2+ requires PHP 7 and our pipelines run on php 5.6 so we need to lock to version 1.4.2