### PR TITLE
Fix PHPUnit group lists

### DIFF
--- a/tests/Environment/DotenvTest.php
+++ b/tests/Environment/DotenvTest.php
@@ -4,7 +4,6 @@ namespace Tests\Environment;
 /**
  * Dotenv Test
  *
- * @author Leonid Mamchenkov <l.mamchenkov@qobo.biz>
  * @group  environment
  */
 class DotenvTest extends \PHPUnit_Framework_TestCase

--- a/tests/Example/PHPUnitExampleTest.php
+++ b/tests/Example/PHPUnitExampleTest.php
@@ -4,7 +4,6 @@ namespace Tests\Example;
 /**
  * PHPUnit Example Test
  *
- * @author Leonid Mamchenkov <l.mamchenkov@qobo.biz>
  * @group  example
  */
 class PHPUnitExampleTest extends \PHPUnit_Framework_TestCase

--- a/tests/Unit/ComposerTest.php
+++ b/tests/Unit/ComposerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit;
 /**
  * Composer Test
  *
- * @author Leonid Mamchenkov <l.mamchenkov@qobo.biz>
  */
 class ComposerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/DotenvTest.php
+++ b/tests/Unit/DotenvTest.php
@@ -5,8 +5,6 @@ use \Dotenv;
 
 /**
  * Dotenv Test
- *
- * @author Leonid Mamchenkov <l.mamchenkov@qobo.biz>
  */
 class DotenvTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/FaviconTest.php
+++ b/tests/Unit/FaviconTest.php
@@ -3,8 +3,6 @@ namespace Tests\Unit;
 
 /**
  * Favicon Test
- *
- * @author Leonid Mamchenkov <l.mamchenkov@qobo.biz>
  */
 class FaviconTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/RobotsTest.php
+++ b/tests/Unit/RobotsTest.php
@@ -3,8 +3,6 @@ namespace Tests\Unit;
 
 /**
  * Robots Test
- *
- * @author Leonid Mamchenkov <l.mamchenkov@qobo.biz>
  */
 class RobotsTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
The `@author` annotation interferes with PHPUnit group lists.
Removing.

https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.annotations.author