### PR TITLE
Fix chown/chgrp on BitBucket Pipelines

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -13,7 +13,7 @@ pipelines:
           - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           - chmod -R u+rwX,go-rwX ~/.ssh
           - ./bin/composer install --no-interaction --no-progress --no-suggest
-          - ./bin/build app:install CHOWN_USER=$USER,CHGRP_GROUP=$USER,DB_NAME=app,DB_ADMIN_USER=root,DB_ADMIN_PASS=root,DB_USER=root,DB_PASS=root
+          - ./bin/build app:install CHOWN_USER=root,CHGRP_GROUP=root,DB_NAME=app,DB_ADMIN_USER=root,DB_ADMIN_PASS=root,DB_USER=root,DB_PASS=root
           - ./vendor/bin/phpunit --group example --no-coverage
           - ./vendor/bin/phpunit --exclude-group example --no-coverage
           - ./vendor/bin/phpcs


### PR DESCRIPTION
BitBucket Pipelines tests run in a Docker container, based
on Debian Linux distribution.  For some reason, the `$USER`
environment variable is not exported for the user root.

Therefor, we are switching to a fixed value.