### PR TITLE
Changed build logs folder location (task #5101)

### DIFF
--- a/build/Robo/Task/Build/Base.php
+++ b/build/Robo/Task/Build/Base.php
@@ -13,8 +13,8 @@ class Base extends \Qobo\Robo\AbstractCmdTask
             'cmd'   => './vendor/bin/phpunit',
             'path'  => ['./tests'],
             'batch' => true,
-            'out'  => 'build/coverage',
-            'logs'  => 'build/logs'
+            'out'  => 'build/test-coverage',
+            'logs'  => 'build/test-results'
         ],
         'phpcs' => [
             'cmd'   => './vendor/bin/phpcs',
@@ -26,13 +26,13 @@ class Base extends \Qobo\Robo\AbstractCmdTask
             'path'  => ['./src'],
             'batch' => false,
             'out'  => 'build/pdepend',
-            'logs'  => 'build/logs'
+            'logs'  => 'build/test-results'
         ],
         'phploc' => [
             'cmd'   =>  './vendor/bin/phploc --count-tests --log-csv %%LOGS%%/phploc.csv --log-xml %%LOGS%%/phploc.xml %%PATH%%',
             'path'  => ['./src', './tests'],
             'batch' => true,
-            'logs'  => 'build/logs'
+            'logs'  => 'build/test-results'
         ],
         'phpmd' => [
             'cmd'   => './vendor/bin/phpmd %%PATH%% text codesize,controversial,naming,unusedcode',
@@ -43,13 +43,13 @@ class Base extends \Qobo\Robo\AbstractCmdTask
             'cmd'   => './vendor/bin/phpmd %%PATH%% xml codesize,controversial,naming,unusedcode --reportfile %%LOGS%%/phpmd.xml',
             'path'  => ['./src'],
             'batch' => false,
-            'logs'  => 'build/logs'
+            'logs'  => 'build/test-results'
         ],
         'phpcpd' => [
             'cmd'   => './vendor/bin/phpcpd --log-pmd=%%LOGS%%/phpcpd.xml %%PATH%%',
             'path'  => ['./src'],
             'batch' => false,
-            'logs'  => 'build/logs'
+            'logs'  => 'build/test-results'
         ],
         'sami' => [
             'cmd'   => './vendor/bin/sami.php update etc/sami/source.php',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,10 +14,10 @@
 
 	<logging>
 		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+		<log type="coverage-html" target="build/test-coverage"/>
+		<log type="coverage-clover" target="build/test-results/clover.xml"/>
+		<log type="coverage-crap4j" target="build/test-results/crap4j.xml"/>
+		<log type="junit" target="build/test-results/junit.xml" logIncompleteSkipped="false"/>
 	</logging>
 
 	<testsuites>


### PR DESCRIPTION
Changed `build/logs` to `build/test-results` and `build/test-coverage`
in order to take advantage of the BitBucket Pipelines test results
rendering.

https://confluence.atlassian.com/bitbucket/test-reporting-in-pipelines-939708543.html