### PR TITLE
Start PHP web server earlier on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,9 @@ matrix:
         - php: nightly
 
 install:
+    - ./bin/phpserv >/dev/null 2>&1 &
     - ./bin/composer install --no-interaction --no-progress --no-suggest
     - ./bin/build app:install CHOWN_USER=$USER,CHGRP_GROUP=$USER,DB_NAME=app,DB_ADMIN_USER=root,DB_USER=root
-
-before_script:
-    - ./bin/phpserv >/dev/null 2>&1 &
-    - sleep 10
 
 script:
     - ./vendor/bin/phpunit --group example --no-coverage


### PR DESCRIPTION
It takes some time to start the PHP web server (especially with
PHP 5).  Instead of guessing the number of seconds to sleep, we
start it earlier.  By the time composer and other steps are done
it should be sufficient time for the web server to kick in.