### PR TITLE
Minor fixes in Robo build scripts

### DIFF
--- a/build/Robo/Task/Build/Base.php
+++ b/build/Robo/Task/Build/Base.php
@@ -2,6 +2,8 @@
 
 namespace Qobo\Robo\Task\Build;
 
+use Robo\Result;
+
 class Base extends \Qobo\Robo\AbstractCmdTask
 {
     /**
@@ -88,7 +90,7 @@ class Base extends \Qobo\Robo\AbstractCmdTask
                 $this->tasks[$this->taskKey],
                 array_filter($this->data, function ($item){ return ($item === null) ? false : true; })
               )
-            : $this->tasks[$tihs->taskKey];
+            : $this->tasks[$this->taskKey];
 
         return parent::run();
     }


### PR DESCRIPTION
These two issues (missing class use statement and a typo in the
variable) were identified by PHPStan.