### PR TITLE
Updated to Qobo Robo v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=5.6.0",
         "pyrech/composer-changelogs": "~1.4",
-        "qobo/qobo-robo": "^1.0",
+        "qobo/qobo-robo": "^2.0",
         "vlucas/phpdotenv": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
Changelogs summary:

 - twig/twig removed (installed version was v1.35.3)

 - theseer/fdomdocument removed (installed version was 1.6.6)

 - symfony/config removed (installed version was v3.2.14)

 - sebastian/phpcpd removed (installed version was 3.0.1)

 - sebastian/finder-facade removed (installed version was 1.2.2)

 - pimple/pimple removed (installed version was v3.2.3)

 - phpmd/phpmd removed (installed version was 2.6.0)

 - phploc/phploc removed (installed version was 4.0.1)

 - pdepend/pdepend removed (installed version was 2.5.2)

 - nikic/php-parser removed (installed version was v1.4.1)

 - michelf/php-markdown removed (installed version was 1.8.0)

 - composer/ca-bundle removed (installed version was 1.1.1)

 - blackfire/php-sdk removed (installed version was v1.13.0)

 - symfony/dependency-injection removed (installed version was v3.1.10)

 - sami/sami removed (installed version was v3.3.0)

 - symfony/process updated from v2.8.38 to v3.4.8
   See changes: https://github.com/symfony/process/compare/v2.8.38...v3.4.8
   Release notes: https://github.com/symfony/process/releases/tag/v3.4.8

 - symfony/finder updated from v2.8.38 to v3.4.8
   See changes: https://github.com/symfony/finder/compare/v2.8.38...v3.4.8
   Release notes: https://github.com/symfony/finder/releases/tag/v3.4.8

 - symfony/event-dispatcher updated from v3.2.14 to v3.4.8
   See changes: https://github.com/symfony/event-dispatcher/compare/v3.2.14...v3.4.8
   Release notes: https://github.com/symfony/event-dispatcher/releases/tag/v3.4.8

 - symfony/debug updated from v3.0.9 to v3.4.8
   See changes: https://github.com/symfony/debug/compare/v3.0.9...v3.4.8
   Release notes: https://github.com/symfony/debug/releases/tag/v3.4.8

 - symfony/console updated from v2.8.38 to v3.4.8
   See changes: https://github.com/symfony/console/compare/v2.8.38...v3.4.8
   Release notes: https://github.com/symfony/console/releases/tag/v3.4.8

 - symfony/yaml updated from v2.8.38 to v3.4.8
   See changes: https://github.com/symfony/yaml/compare/v2.8.38...v3.4.8
   Release notes: https://github.com/symfony/yaml/releases/tag/v3.4.8

 - webmozart/assert installed in version 1.3.0
   Release notes: https://github.com/webmozart/assert/releases/tag/1.3.0

 - phpdocumentor/reflection-common installed in version 1.0.1
   Release notes: https://github.com/phpDocumentor/ReflectionCommon/releases/tag/1.0.1

 - phpdocumentor/type-resolver installed in version 0.4.0
   Release notes: https://github.com/phpDocumentor/TypeResolver/releases/tag/0.4.0

 - phpdocumentor/reflection-docblock updated from 2.0.5 to 3.3.2
   See changes: https://github.com/phpDocumentor/ReflectionDocBlock/compare/2.0.5...3.3.2
   Release notes: https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/3.3.2

 - qobo/qobo-robo updated from v1.1.1 to v2.0.0
   See changes: https://github.com/QoboLtd/qobo-robo/compare/v1.1.1...v2.0.0
   Release notes: https://github.com/QoboLtd/qobo-robo/releases/tag/v2.0.0