### PR TITLE
Revert "Re-enable test coverage reports on pipelines (task #5051)"

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -19,5 +19,5 @@ pipelines:
           - ./bin/composer install --no-interaction --no-progress --no-suggest
           - ./bin/build app:install CHOWN_USER=root,CHGRP_GROUP=root,DB_NAME=app,DB_ADMIN_USER=root,DB_ADMIN_PASS=root,DB_USER=root,DB_PASS=root
           - ./vendor/bin/phpunit --group example --no-coverage
-          - ./vendor/bin/phpunit --exclude-group example
+          - ./vendor/bin/phpunit --exclude-group example --no-coverage
           - ./vendor/bin/phpcs


### PR DESCRIPTION
This reverts commit 056eb564f2dc9af9a77455d655840340260beb67.

BitBucket Pipelines run a lot slower with the code coverage reports
enabled.  On some projects, the difference can be 5 minutes (without)
versus 25 minutes (with).  Given that Atlassian charges for the
BitBucket Pipelines minutes, we should try to keep them to the
minimum.