### PR TITLE
Fix mysql container startup check for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,10 @@ services:
     user: ${FIXUID-1000}:${FIXGID-1000}
     entrypoint: >
       bash -c "set -x
+      && echo 'waiting for mysql to start'
+      && sh -c 'until printf \"\" 2>>/dev/null >> /dev/tcp/mysql/3306; do sleep 1; done'
+      && echo 'mysql is up'
       && cd /var/www/html
-      && ping -c 3 mysql
       && mysql -h mysql -u root -proot -e 'drop database if exists app'
       && /usr/bin/fixuid
       && ./bin/composer validate --strict
@@ -40,8 +42,9 @@ services:
       - ./:/code
     entrypoint: >
       bash -c "set -x
-      && echo 'Check DB'
-      && ping -c 3 mysql
+      && echo 'waiting for mysql to start'
+      && sh -c 'until printf \"\" 2>>/dev/null >> /dev/tcp/mysql/3306; do sleep 1; done'
+      && echo 'mysql is up'
       && mysql -h mysql -u root -proot -e 'drop database if exists app'
       && echo 'Check PHP Version'
       && php --version


### PR DESCRIPTION
Sometimes bitbucket pipeline would fail due to MySQL dependency container not being fast enough to initialise, so instead of waiting for 3 seconds we need to check for port 3306 to be available:

* Remove the 3 seconds ping of mysql
* Add waiting for port 3306 to become available