### PR TITLE
Composer test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 .env
 etc/nginx.conf
 etc/ssl/*
+cghooks.lock

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "extra": {
         "hooks": {
-            "pre-commit": "composer test"
+            "pre-commit": "./vendor/bin/phpcs"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "vlucas/phpdotenv": "^1.1"
     },
     "require-dev": {
+        "brainmaestro/composer-git-hooks": "^2.4",
         "phpunit/phpunit": "*",
         "squizlabs/php_codesniffer": "*"
     },
@@ -39,6 +40,27 @@
     "autoload": {
         "psr-4": {
             "Qobo\\Robo\\": "build/Robo"
+        }
+    },
+    "scripts": {
+        "test": [
+            "phpcs",
+            "phpunit --no-coverage"
+        ],
+        "test-coverage": [
+            "phpcs",
+            "phpunit"
+        ],
+        "post-install-cmd": "cghooks add --ignore-lock",
+        "post-update-cmd": "cghooks update"
+    },
+    "scripts-descriptions": {
+        "test": "Runs phpcs and phpunit without coverage",
+        "test-coverage": "Runs phpcs and phpunit with coverage enabled"
+    },
+    "extra": {
+        "hooks": {
+            "pre-commit": "composer test"
         }
     }
 }


### PR DESCRIPTION
- Adds `test` composer command which runs phpcs and phpunit without coverage
- Adds `test-coverage` composer command which runs phpcs and phpunit with coverage enabled
- Adds git pre-commit hook to execute phpcs prior to commit. If necessary we can bypass the hooks with the following  

`git commit --no-verify`