### PR TITLE
Move cghooks from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     },
     "require": {
         "aws/aws-sdk-php": "^3.52",
+        "brainmaestro/composer-git-hooks": "^2.4",
         "pyrech/composer-changelogs": "~1.4",
         "qobo/qobo-robo": "^2.0",
         "vlucas/phpdotenv": "^1.1"
     },
     "require-dev": {
-        "brainmaestro/composer-git-hooks": "^2.4",
         "phpunit/phpunit": "*",
         "squizlabs/php_codesniffer": "*"
     },


### PR DESCRIPTION
Since cghooks are used in the post-install command which is not
limited to the developer mode alone, cghooks should be generally
available.