### PR TITLE
Treat zip files as binary in git attributes (task #7698)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,3 +44,6 @@ composer binary
 *.ttf binary
 *.woff binary
 *.woff2 binary
+
+# Treat zip files as binary
+*.zip binary


### PR DESCRIPTION
Treat zip files as binary in git attributes. 

Currently zips are causing an issue in the WordPress template as pre-commit phpcs finds errors in the zipped plugins in custom-themes/custom/plugins 

(task #7698)

