### PR TITLE
Improve PHPCS for pre-commit (task-7717)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,10 @@
             "phpunit"
         ],
         "post-install-cmd": "cghooks add",
-        "post-update-cmd": "cghooks update"
+        "post-update-cmd": [
+            "cghooks remove pre-commit",
+            "cghooks update"
+        ]
     },
     "scripts-descriptions": {
         "test": "Runs phpcs and phpunit without coverage",
@@ -60,7 +63,7 @@
     },
     "extra": {
         "hooks": {
-            "pre-commit": "./vendor/bin/phpcs $(git diff-index --name-only --cached --diff-filter=ACMR HEAD -- )"
+            "pre-push": "./vendor/bin/phpcs"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "extra": {
         "hooks": {
-            "pre-commit": "./vendor/bin/phpcs $(git diff-index --name-only --cached --diff-filter=ACMR HEAD -- | egrep '^src/|^tests/|^webroot/' | egrep '\\.php$')"
+            "pre-commit": "PHPCS_FILES=$(git diff-index --name-only --cached --diff-filter=ACMR HEAD -- | egrep '^src/|^tests/|^webroot/' | egrep '\\.php$'); if [ $PHPCS_FILES ]; then ./vendor/bin/phpcs $PHPCS_FILES; fi"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "extra": {
         "hooks": {
-            "pre-commit": "PHPCS_FILES=$(git diff-index --name-only --cached --diff-filter=ACMR HEAD -- | egrep '^src/|^tests/|^webroot/' | egrep '\\.php$'); if [ $PHPCS_FILES ]; then ./vendor/bin/phpcs $PHPCS_FILES; fi"
+            "pre-commit": "PHPCS_FILES=$(git diff-index --name-only --cached --diff-filter=ACMR HEAD 'tests/**.php' 'src/**.php' 'webroot/**.php'); if [ \"$PHPCS_FILES\" ]; then ./vendor/bin/phpcs $PHPCS_FILES; fi"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -52,10 +52,7 @@
             "phpunit"
         ],
         "post-install-cmd": "cghooks add",
-        "post-update-cmd": [
-            "cghooks remove pre-commit",
-            "cghooks update"
-        ]
+        "post-update-cmd": "cghooks update"
     },
     "scripts-descriptions": {
         "test": "Runs phpcs and phpunit without coverage",
@@ -63,7 +60,7 @@
     },
     "extra": {
         "hooks": {
-            "pre-push": "./vendor/bin/phpcs"
+            "pre-commit": "./vendor/bin/phpcs $(git diff-index --name-only --cached --diff-filter=ACMR HEAD -- | egrep '^src/|^tests/|^webroot/' | egrep '\\.php$')"
         }
     }
 }


### PR DESCRIPTION
This PR improves the existing support for PHPCS, available as a pre-commit hook so that:

* Only PHP files located under `src`, `tests` and `webroot` are passed to PHPCS
* PHPCS is being executed only and only if there are files to be committed, matching the above criteria