### PR TITLE
PHP CodeSniffer configuration tweaks

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,3 +2,4 @@ linters:
   phpcs:
     standard: PSR2
     extensions: '.php'
+    exclude: 'Generic.Commenting.Todo'

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,9 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="PSR2" />
+    <rule ref="PSR2">
+        <exclude name="Generic.Commenting.Todo" />
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
@@ -27,4 +29,7 @@
     <file>./src/</file>
     <file>./tests/</file>
     <file>./webroot/</file>
+
+    <!-- Ignore minified files -->
+    <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
* Exclude warnings about TODO comments
* Exclude minimified CSS and JavaScript files