### PR TITLE
Fix docker-compose by adding more deps (task #10634)

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -11,7 +11,7 @@ pipelines:
           services:
             - docker
           script:
-            - apk add --no-cache py-pip bash rsync
+            - apk add --no-cache py-pip bash rsync python python-dev build-base libffi-dev openssl-dev libgcc
             - rsync -avg ~/.composer/ ./build/composer/
             - pip install docker-compose
             - docker-compose -v
@@ -29,7 +29,7 @@ pipelines:
           services:
             - docker
           script:
-            - apk add --no-cache py-pip bash rsync
+            - apk add --no-cache py-pip bash rsync python python-dev build-base libffi-dev openssl-dev libgcc
             - rsync -avg ~/.composer/ ./build/composer/
             - pip install docker-compose
             - docker-compose -v


### PR DESCRIPTION
Docker compose 1.24.0+ required more deps and bitbucket
pipelines fail to run without them.

Add more deps for the container before installing
docker compose as described here:
https://github.com/docker/compose/issues/6617